### PR TITLE
Refactor Custom Button input

### DIFF
--- a/class_buttons.py
+++ b/class_buttons.py
@@ -1,44 +1,73 @@
+"""Custom image-based buttons with animations"""
+
 import tkinter as tk
 
-class ImageButton(tk.Label):
-	def __init__(self, root, image_paths, *args, **kwargs):
-		self.normal_image = tk.PhotoImage(file = image_paths[0])
-		self.hovered_image = tk.PhotoImage(file = image_paths[1])
-		self.pressed_image = tk.PhotoImage(file = image_paths[2])
-		self.command = kwargs.pop('command', None)
-		disabled = kwargs.pop('state', None) == tk.DISABLED
+# To avoid creating a new image for each state, this opt-out cache is available.
+IMAGE_CACHE = {}
 
-		super().__init__(master = root, image=self.normal_image, font=kwargs.pop('font', ('Arial', 18, 'bold')), bg=kwargs.pop('bg', '#333333'), compound=kwargs.pop('compound', 'center'), *args, **kwargs)
+def load_images(normal=None, hover=None, pressed=None, cache=True):
+	"""Return images - either from cache or from filepaths"""
+	return (
+		[IMAGE_CACHE.setdefault(filepath, tk.PhotoImage(file=filepath)) for filepath in (normal, hover, pressed)]
+		if cache else
+		[tk.PhotoImage(file=filepath) for filepath in (normal, hover, pressed)]
+	)
+
+
+class ImageButton(tk.Button):
+	"""Button with image-based animations"""
+	def __init__(self, *args, image_paths=None, disable_cache=False, cursors=['hand1', 'X_cursor'], **kwargs):
+		image_paths = image_paths or []
+
+		normal, hover, pressed = load_images(*image_paths, cache=not disable_cache)
+		self.image_events = {
+			normal: ('<ButtonRelease-1>', '<Leave>', '<FocusOut>'),
+			hover: ('<Enter>', '<FocusIn>'),
+			pressed: ('<Button-1>', )
+		}
+
+		self.cursors = cursors
+
+		disabled = kwargs.pop('state', None) == tk.DISABLED
+		bg = kwargs.pop('bg', '#333333')
+
+		super().__init__(
+			image=list(self.image_events.keys())[0],
+			font=kwargs.pop('font', ('Arial', 18, 'bold')),
+			bg=bg,
+			activebackground=bg,
+			compound=kwargs.pop('compound', 'center'),
+			borderwidth=0,
+			highlightthickness=0,
+			*args,
+			**kwargs
+		)
 		self.disabled = disabled
+		self.bind('<Return>', lambda _: self.invoke())
 
 	@property
 	def disabled(self):
+		"""Return disabled state of button"""
 		return self['state'] == tk.DISABLED
 
 	@disabled.setter
-	def disabled(self, value):
-		self['state'] = tk.DISABLED if value else tk.NORMAL
-		self['cursor'] = 'X_cursor' if value else 'hand1'
-		self.bind('<Button-1>',
-			lambda _: self.config(image = self.pressed_image) if not value else lambda _: None
-		)
-		self.bind('<ButtonRelease-1>',
-			self.on_release if not value else lambda _: None
-		)
-		self.bind('<Enter>',
-			lambda _: self.config(image = self.hovered_image) if not value else lambda _: None
-		)
-		self.bind('<Leave>',
-			lambda _: self.config(image = self.normal_image) if not value else lambda _: None
-		)
+	def disabled(self, disabled):
+		"""Set disabled state"""
+		self['state'] = tk.DISABLED if disabled else tk.NORMAL
+		self['cursor'] = self.cursors[int(disabled)]
 
-	def on_release(self, arg):
-		self.config(image = self.normal_image)
-		if self.command:
-			self.command(self)
+		if disabled:
+			for events in self.image_events.values():
+				for event in events:
+					self.unbind(event)
+			return
+
+		for image, events in ((image, events) for image, events in self.image_events.items() if image):
+			for event in events:
+				self.bind(event, lambda _, image=image: self.config(image=image))
 
 
 class Button(ImageButton):
-	def __init__(self, root = None, text = '', command = None, *args, **kwargs):
-		super().__init__(root = root, image_paths = ('images/normal_button.png', 'images/hovered_button.png', 'images/pressed_button.png'), text = text, command = command, *args, **kwargs)
-
+	"""Pre-styled image button"""
+	def __init__(self, *args, **kwargs):
+		super().__init__(image_paths=['images/normal_button.png', 'images/hovered_button.png', 'images/pressed_button.png'], *args, **kwargs)

--- a/main.py
+++ b/main.py
@@ -48,9 +48,9 @@ class MainMenu(tk.Frame):
         tk.Label(self, bg = '#333333').pack(pady = 25) # spacing
 
         # using custom buttons for the ui
-        Button(root = self, text='Start', command = lambda x: master.switch_frame(SelectMode)).pack(pady = 15)
-        Button(root = self, text='Help', command = lambda x: master.switch_frame(Help)).pack(pady = 15)
-        Button(root = self, text='Exit', command = lambda x: master.destroy()).pack(pady = 15)
+        Button(self, text='Start', command = lambda: master.switch_frame(SelectMode)).pack(pady = 15)
+        Button(self, text='Help', command = lambda: master.switch_frame(Help)).pack(pady = 15)
+        Button(self, text='Exit', command = lambda: master.destroy()).pack(pady = 15)
 
     
 
@@ -65,9 +65,9 @@ class Help(tk.Frame):
         github_link = "https://github.com/RascalTwo/PythonBuddiesPasswordGenerator"
         discord_link = "https://discord.gg/ED8kU5K"
 
-        Button(root = self, text='GitHub', command = lambda x: webbrowser.open(github_link)).pack(pady = 15)
-        Button(root = self, text='Discord', command = lambda x: webbrowser.open(discord_link)).pack(pady = 15)
-        Button(root = self, text='Back', command = lambda x: master.switch_frame(MainMenu)).pack(pady = 15)
+        Button(self, text='GitHub', command = lambda: webbrowser.open(github_link)).pack(pady = 15)
+        Button(self, text='Discord', command = lambda: webbrowser.open(discord_link)).pack(pady = 15)
+        Button(self, text='Back', command = lambda: master.switch_frame(MainMenu)).pack(pady = 15)
 
 
 
@@ -80,9 +80,9 @@ class SelectMode(tk.Frame):
         tk.Label(self, bg = '#333333').pack(pady = 25) # spacing
 
         # using custom buttons for the ui
-        Button(root = self, text='Fully Random', command = lambda x: master.switch_frame(FullyRandom)).pack(pady = 15)
-        Button(root = self, text='Easy to Remember', command = lambda x: master.switch_frame(EasyToRemember)).pack(pady = 15)
-        Button(root = self, text='Back', command = lambda x: master.switch_frame(MainMenu)).pack(pady = 15)
+        Button(self, text='Fully Random', command = lambda: master.switch_frame(FullyRandom)).pack(pady = 15)
+        Button(self, text='Easy to Remember', command = lambda: master.switch_frame(EasyToRemember)).pack(pady = 15)
+        Button(self, text='Back', command = lambda: master.switch_frame(MainMenu)).pack(pady = 15)
 
 
 
@@ -103,13 +103,13 @@ class EasyToRemember(tk.Frame):
         self.entry_year = Entry(self, alt_text='Your birth year')
         self.entry_year.pack(pady = 10)
 
-        Button(root = self, text='Confirm', command = lambda x: self.generate_password(None)).pack(pady = 15)
+        Button(self, text='Confirm', command = lambda: self.generate_password(None)).pack(pady = 15)
 
         self.entry_password = tk.Entry(self, font = ("Arial", 18, "bold"), bg = "#a8a8a8", fg = "#181818", borderwidth = 2, relief = "solid")
         self.entry_password.pack(pady = 15)
 
-        Button(root = self, text='Copy', command = lambda x: pyperclip.copy(self.entry_password.get())).pack(pady = 15)
-        Button(root = self, text='Back', command = lambda x: master.switch_frame(SelectMode)).pack(pady = 15)
+        Button(self, text='Copy', command = lambda: pyperclip.copy(self.entry_password.get())).pack(pady = 15)
+        Button(self, text='Back', command = lambda: master.switch_frame(SelectMode)).pack(pady = 15)
 
     
     def generate_password(self, temp):
@@ -155,13 +155,13 @@ class FullyRandom(tk.Frame):
         self.entry_special = Entry(self, alt_text='Number of special')
         self.entry_special.pack(pady = 10)
 
-        Button(root = self, text='Confirm', command = self.generate_password).pack(pady = 15)
+        Button(self, text='Confirm', command = self.generate_password).pack(pady = 15)
 
         self.entry_password = tk.Entry(self, font = ("Arial", 18, "bold"), bg = "#a8a8a8", fg = "#181818", borderwidth = 2, relief = "solid")
         self.entry_password.pack(pady = 15)
 
-        Button(root = self, text='Copy', command = lambda x: pyperclip.copy(self.entry_password.get())).pack(pady = 15)
-        Button(root = self, text='Back', command = lambda x: master.switch_frame(SelectMode)).pack(pady = 15)
+        Button(self, text='Copy', command = lambda: pyperclip.copy(self.entry_password.get())).pack(pady = 15)
+        Button(self, text='Back', command = lambda: master.switch_frame(SelectMode)).pack(pady = 15)
 
     
     def generate_password(self, temp):


### PR DESCRIPTION
So I was able to change the base class from `Label` to `Button` without losing any functionality.

Also implemented image caching, along with making them optional.

Now that the button inherits from `Button`, tab-focusing works! By default the `Space` key is the only thing that invokes the command, so event listener for the Enter/Return button has been manually added.

Close #4

***

Asking for review due to the fact that there is one style change: the relief is not manually set, so when pressing there's the effect in which the button slightly moves.